### PR TITLE
Add option to limit recursion depth

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<Configuration status="WARN">
+	<Appenders>
+		<Console name="STDOUT" target="SYSTEM_OUT">
+			<PatternLayout pattern="%d{HH:mm:ss,SSS} %-5p %C{1} %m%n"/>
+			<ThresholdFilter level="DEBUG"/>
+		</Console>
+	</Appenders>
+	<Loggers>
+		<Logger level="INFO" name="de.fraunhofer.aisec"/>
+		<Root level="INFO">
+			<AppenderRef ref="STDOUT"/>
+		</Root>
+	</Loggers>
+</Configuration>


### PR DESCRIPTION
When inserting a Node, all child nodes are added recursively by neo4j OGM.
With large graphs, this slows down the insert process and can cause a StackOverflowError.
With this new `--depth N` option, the recursion depth for neo4j OGM can be limited.
On the downside, this option can result in missing Nodes, which are not part of the AST and not reachable within `N` hops.
But this is at the moment the only option to import larger code base from the cpg into neo4j.